### PR TITLE
Create Stack using priority queue or heap

### DIFF
--- a/Stack using priority queue or heap
+++ b/Stack using priority queue or heap
@@ -1,0 +1,55 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+typedef pair<int, int> pi;
+
+
+class Stack{
+	
+	
+	int cnt;
+	priority_queue<pair<int, int> > pq;
+public:
+	Stack():cnt(0){}
+	void push(int n);
+	void pop();
+	int top();
+	bool isEmpty();
+};
+
+
+void Stack::push(int n){
+	cnt++;
+	pq.push(pi(cnt, n));
+}
+
+
+void Stack::pop(){
+	if(pq.empty()){ cout<<"Nothing to pop!!!";}
+	cnt--;
+	pq.pop();
+}
+
+
+int Stack::top(){
+	pi temp=pq.top();
+	return temp.second;
+}
+
+
+bool Stack::isEmpty(){
+	return pq.empty();
+}
+
+
+int main()
+{
+	Stack* s=new Stack();
+	s->push(1);
+	s->push(2);
+	s->push(3);
+	while(!s->isEmpty()){
+		cout<<s->top()<<endl;
+		s->pop();
+	}
+}


### PR DESCRIPTION
In priority queue, we assign priority to the elements that are being pushed. A stack requires elements to be processed in Last in First Out manner. The idea is to associate a count that determines when it was pushed. This count works as a key for the priority queue. So the implementation of stack uses a priority queue of pairs, with the first element serving as the key.
Time Complexity: O(logn)
Auxiliary Space: O(n) where n is size of priority queue